### PR TITLE
feature: added routes for kube's healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ WORKDIR /usr/build/mail
 COPY --from=mail-pnpm /usr/build/mail .
 
 HEALTHCHECK --interval=1m --timeout=10s --retries=5 --start-period=20s \
-  CMD wget -Y off --no-verbose --tries=1 --spider http://localhost:8080/ || exit 1
+  CMD wget -Y off --no-verbose --tries=1 --spider http://localhost:8080/liveness || exit 1
 
 CMD [ "npm", "run", "start" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ COPY --from=report-pnpm /usr/build/report .
 COPY --from=report-prisma /usr/build/report-dev/.prisma ./.prisma
 
 HEALTHCHECK --interval=1m --timeout=10s --retries=5 --start-period=20s \
-  CMD wget -Y off --no-verbose --tries=1 --spider http://localhost:8080/health/ezreeport-report || exit 1
+  CMD wget -Y off --no-verbose --tries=1 --spider http://localhost:8080/health/probes/liveness || exit 1
 
 CMD [ "npm", "run", "start" ]
 

--- a/services/mail/src/app.ts
+++ b/services/mail/src/app.ts
@@ -1,20 +1,35 @@
 import http from 'node:http';
 
-import * as checks from '~/models/healthchecks';
+import healthChecks from '~/models/healthchecks';
 
 import { appLogger } from '~/lib/logger';
 
 const server = http.createServer((req, res) => {
-  Promise.all(
-    Array.from(checks.services).map((s) => checks.ping(s)),
-  ).then(() => {
-    res.writeHead(200);
-    res.end('OK');
-  }).catch((err) => {
-    appLogger.error(`Error when getting services: ${err}`);
-    res.writeHead(500);
-    res.end(`ERROR: ${err}`);
-  });
+  switch (req.url) {
+    // Liveness probe, check if the server is up
+    case '/liveness':
+    case '/liveness/':
+      res.writeHead(204).end();
+      break;
+
+    // Readiness probe, check if the server is ready
+    case '/readiness':
+    case '/readiness/':
+      healthChecks()
+        .then(() => {
+          res.writeHead(204).end();
+        })
+        .catch((err) => {
+          appLogger.error(`[health] ${err}`);
+          res.writeHead(503).end(JSON.stringify(err));
+        });
+      break;
+
+    // Route not found
+    default:
+      res.writeHead(404).end();
+      break;
+  }
 });
 
 server.listen(8080, 'localhost', () => {

--- a/services/mail/src/models/healthchecks.ts
+++ b/services/mail/src/models/healthchecks.ts
@@ -13,14 +13,14 @@ const pingers = {
 
 type Service = keyof typeof pingers;
 
-export const services = new Set(Object.keys(pingers) as Service[]);
+const services = new Set(Object.keys(pingers) as Service[]);
 
 /**
  * Exec ping & calculate time taken.
  *
  * @param service Service name
  */
-export const ping = async (
+const ping = async (
   service: Service,
   timeout = 10000,
 ) => {
@@ -46,3 +46,5 @@ export const ping = async (
     throw new Error(error instanceof Error ? error.message : `Unexpected error: ${error}`);
   }
 };
+
+export default () => Promise.all(Array.from(services).map((s) => ping(s)));

--- a/services/report/src/models/healthchecks.ts
+++ b/services/report/src/models/healthchecks.ts
@@ -24,12 +24,12 @@ interface Pong {
   status: boolean;
 }
 
-interface SuccessfulPong extends Pong {
+export interface SuccessfulPong extends Pong {
   elapsedTime: number;
   statusCode?: number;
 }
 
-interface ErrorPong extends Pong {
+export interface ErrorPong extends Pong {
   status: false;
   error: string;
 }
@@ -89,6 +89,8 @@ export const ping = async (
     };
   }
 };
+
+export const pingAll = () => Promise.all(Array.from(services).map((service) => ping(service)));
 
 export {
   name as serviceName,

--- a/services/report/src/plugins/logger.ts
+++ b/services/report/src/plugins/logger.ts
@@ -19,12 +19,12 @@ const logRequest = (request: FastifyRequest, reply?: FastifyReply) => {
 
   const duration = differenceInMilliseconds(end, start);
 
-  let log = accessLogger.error;
+  let level = 'error';
   if (reply && reply.statusCode >= 200 && reply.statusCode < 300) {
-    log = accessLogger.info;
+    level = request.routeOptions?.logLevel || 'info';
   }
 
-  log(`${request.method} ${request.url} - ${reply?.statusCode ?? 0} (${duration})`);
+  accessLogger.log(level, `${request.method} ${request.url} - ${reply?.statusCode ?? 0} (${duration})`);
 };
 
 /**

--- a/services/report/src/routes/v1/health.ts
+++ b/services/report/src/routes/v1/health.ts
@@ -59,7 +59,7 @@ const router: FastifyPluginAsync = async (fastify) => {
   );
 
   /**
-   * Liveness probe
+   * Liveness probe, check if the server is up
    */
   fastify.get(
     '/probes/liveness',
@@ -67,7 +67,7 @@ const router: FastifyPluginAsync = async (fastify) => {
   );
 
   /**
-   * Readiness probe
+   * Readiness probe, check if the server is ready
    */
   fastify.get(
     '/probes/readiness',

--- a/services/report/src/routes/v1/health.ts
+++ b/services/report/src/routes/v1/health.ts
@@ -12,6 +12,7 @@ const router: FastifyPluginAsync = async (fastify) => {
    */
   fastify.get(
     '/',
+    { logLevel: 'debug' },
     async () => ({
       content: {
         current: checks.serviceName,
@@ -26,6 +27,7 @@ const router: FastifyPluginAsync = async (fastify) => {
    */
   fastify.get(
     '/services/',
+    { logLevel: 'debug' },
     async () => ({
       content: await checks.pingAll(),
     }),
@@ -40,6 +42,7 @@ const router: FastifyPluginAsync = async (fastify) => {
   fastify.get<{ Params: Static<typeof GetServiceParams> }>(
     '/services/:service',
     {
+      logLevel: 'debug',
       schema: {
         params: GetServiceParams,
       },
@@ -63,6 +66,7 @@ const router: FastifyPluginAsync = async (fastify) => {
    */
   fastify.get(
     '/probes/liveness',
+    { logLevel: 'debug' },
     async () => ({}),
   );
 
@@ -71,6 +75,7 @@ const router: FastifyPluginAsync = async (fastify) => {
    */
   fastify.get(
     '/probes/readiness',
+    { logLevel: 'debug' },
     async () => {
       const pongs = await checks.pingAll();
       const failedPong = pongs.find((pong): pong is checks.ErrorPong => !pong.status);

--- a/services/report/src/types/errors.ts
+++ b/services/report/src/types/errors.ts
@@ -2,25 +2,25 @@
 import { StatusCodes } from 'http-status-codes';
 
 export class HTTPError extends Error {
-  constructor(message: string, public statusCode: StatusCodes) {
-    super(message);
+  constructor(message: string, public statusCode: StatusCodes, options?: ErrorOptions) {
+    super(message, options);
   }
 }
 
 export class NotFoundError extends HTTPError {
-  constructor(message: string) {
-    super(message, StatusCodes.NOT_FOUND);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, StatusCodes.NOT_FOUND, options);
   }
 }
 
 export class ArgumentError extends HTTPError {
-  constructor(message: string) {
-    super(message, StatusCodes.BAD_REQUEST);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, StatusCodes.BAD_REQUEST, options);
   }
 }
 
 export class ConflictError extends HTTPError {
-  constructor(message: string) {
-    super(message, StatusCodes.CONFLICT);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, StatusCodes.CONFLICT, options);
   }
 }


### PR DESCRIPTION
# Report

## Features

- Custom log level per route, so no more healthchecks in production logs 

## Routes

```diff
- /healthcheck/:service
+ /healthcheck/service/:service
- /healthcheck/ezreeport-report
+ /healthcheck/service/api
+ /healthcheck/probes/liveness
+ /healthcheck/probes/readiness
```

# Mail

## Routes

```diff
- /
+ /liveness
+ /readiness
```