### PR TITLE
feature: Switched to JSON logs

### DIFF
--- a/.env
+++ b/.env
@@ -54,4 +54,6 @@ REPORT_FETCHER_BANNED_DOMAINS="[]"
 API_URL="http://localhost:8080"
 API_ALLOWED_ORIGINS="*" # Comma separated origins (or * to allow all)
 LOG_LEVEL="info"
+LOG_DIR=""
+LOG_IGNORE="hostname"
 HTTP_PORT=8080

--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ web_modules/
 
 # local config
 local*.json
+local*.yaml
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,9 +162,6 @@ importers:
       pino:
         specifier: ^9.4.0
         version: 9.4.0
-      pino-pretty:
-        specifier: ^11.2.2
-        version: 11.2.2
       tsx:
         specifier: ^4.7.2
         version: 4.7.2
@@ -187,6 +184,9 @@ importers:
       '@types/nunjucks':
         specifier: ^3.2.6
         version: 3.2.6
+      pino-pretty:
+        specifier: ^11.2.2
+        version: 11.2.2
 
   services/report:
     dependencies:
@@ -262,9 +262,6 @@ importers:
       pino:
         specifier: ^9.4.0
         version: 9.4.0
-      pino-pretty:
-        specifier: ^11.2.2
-        version: 11.2.2
       swagger-ui-dist:
         specifier: ^5.10.5
         version: 5.14.0
@@ -296,6 +293,9 @@ importers:
       '@types/swagger-ui-dist':
         specifier: ^3.30.5
         version: 3.30.5
+      pino-pretty:
+        specifier: ^11.2.2
+        version: 11.2.2
       prisma:
         specifier: ^5.7.1
         version: 5.12.1
@@ -8679,7 +8679,6 @@ packages:
     engines: {node: '>=6.5'}
     dependencies:
       event-target-shim: 5.0.1
-    dev: false
 
   /abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
@@ -9194,7 +9193,6 @@ packages:
   /atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
-    dev: false
 
   /autoprefixer@10.4.19(postcss@8.4.38):
     resolution: {integrity: sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==}
@@ -9681,7 +9679,6 @@ packages:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
-    dev: false
 
   /builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
@@ -11335,7 +11332,7 @@ packages:
 
   /dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
-    dev: false
+    dev: true
 
   /de-indent@1.0.2:
     resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
@@ -11364,18 +11361,6 @@ packages:
     dependencies:
       ms: 2.1.3
     dev: true
-
-  /debug@4.3.4:
-    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.2
-    dev: false
 
   /debug@4.3.4(supports-color@8.1.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -12664,7 +12649,6 @@ packages:
   /event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
-    dev: false
 
   /eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
@@ -12868,7 +12852,7 @@ packages:
 
   /fast-copy@3.0.2:
     resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
-    dev: false
+    dev: true
 
   /fast-decode-uri-component@1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
@@ -12925,7 +12909,7 @@ packages:
 
   /fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
-    dev: false
+    dev: true
 
   /fast-uri@2.3.0:
     resolution: {integrity: sha512-eel5UKGn369gGEWOqBShmFJWfq/xSJvsgDzgLYC845GneayWvXBf0lJCBn5qTABfewy1ZDPoaR5OZCP+kssfuw==}
@@ -13920,7 +13904,7 @@ packages:
 
   /help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
-    dev: false
+    dev: true
 
   /highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
@@ -14369,7 +14353,7 @@ packages:
     dependencies:
       '@ioredis/commands': 1.2.0
       cluster-key-slot: 1.1.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -15351,7 +15335,7 @@ packages:
   /joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
-    dev: false
+    dev: true
 
   /js-beautify@1.15.1:
     resolution: {integrity: sha512-ESjNzSlt/sWE8sciZH8kBF8BPlwXPwhR6pWKAw8bw4Bwj+iZcnKW6ONWUutJ7eObuBZQpiIb8S7OYspWrKt7rA==}
@@ -18017,7 +18001,6 @@ packages:
   /on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
-    dev: false
 
   /on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
@@ -18537,7 +18520,6 @@ packages:
     dependencies:
       readable-stream: 4.5.2
       split2: 4.2.0
-    dev: false
 
   /pino-pretty@11.2.2:
     resolution: {integrity: sha512-2FnyGir8nAJAqD3srROdrF1J5BIcMT4nwj7hHSc60El6Uxlym00UbCCd8pYIterstVBFlMyF1yFV8XdGIPbj4A==}
@@ -18557,7 +18539,7 @@ packages:
       secure-json-parse: 2.7.0
       sonic-boom: 4.1.0
       strip-json-comments: 3.1.1
-    dev: false
+    dev: true
 
   /pino-std-serializers@6.2.2:
     resolution: {integrity: sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==}
@@ -20271,7 +20253,6 @@ packages:
       events: 3.3.0
       process: 0.11.10
       string_decoder: 1.3.0
-    dev: false
 
   /readdirp@2.2.1:
     resolution: {integrity: sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==}
@@ -20839,7 +20820,6 @@ packages:
 
   /secure-json-parse@2.7.0:
     resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
-    dev: false
 
   /semantic-release-monorepo@8.0.2(semantic-release@22.0.12):
     resolution: {integrity: sha512-TQC6KKIA0ATjii1OT0ZmQqcVzBJoaetJaJBC8FmKkg1IbDR4wBsuX6gl6UHDdijRDl8YyXqahj2hkJNyV6m9Jg==}
@@ -21319,7 +21299,6 @@ packages:
     resolution: {integrity: sha512-NGipjjRicyJJ03rPiZCJYjwlsuP2d1/5QUviozRXC7S3WdVWNK5e3Ojieb9CCyfhq2UC+3+SRd9nG3I2lPRvUw==}
     dependencies:
       atomic-sleep: 1.0.0
-    dev: false
 
   /sort-keys@1.1.2:
     resolution: {integrity: sha512-vzn8aSqKgytVik0iwdBEi+zevbTYZogewTUM6dtpmGwEcdzbub/TX4bCzRhebDCRC3QzXgJsLRKB2V/Oof7HXg==}
@@ -21753,6 +21732,7 @@ packages:
   /strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+    dev: true
 
   /strnum@1.0.5:
     resolution: {integrity: sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,6 +256,12 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
+      pino:
+        specifier: ^9.4.0
+        version: 9.4.0
+      pino-pretty:
+        specifier: ^11.2.2
+        version: 11.2.2
       swagger-ui-dist:
         specifier: ^5.10.5
         version: 5.14.0
@@ -271,9 +277,6 @@ importers:
       vega-lite:
         specifier: ^5.16.3
         version: 5.17.0(vega@5.28.0)
-      winston:
-        specifier: ^3.13.1
-        version: 3.13.1
     devDependencies:
       '@types/chroma-js':
         specifier: ^2.4.4
@@ -3153,7 +3156,7 @@ packages:
     resolution: {integrity: sha512-GMXtFVqd3FgUlTtPL/GDc+3GhwvfZ0kSuegCvVVqb58kd+0I6U6u7PL8QFRLHtwzqLEBmYLdwr4PRkBAWKGlzA==}
     engines: {node: '>=12'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       hpagent: 0.1.2
       ms: 2.1.3
       secure-json-parse: 2.7.0
@@ -8745,7 +8748,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -9234,7 +9237,7 @@ packages:
     dependencies:
       '@fastify/error': 3.4.1
       archy: 1.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       fastq: 1.17.1
     transitivePeerDependencies:
       - supports-color
@@ -11358,6 +11361,10 @@ packages:
     resolution: {integrity: sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==}
     dev: true
 
+  /dateformat@4.6.3:
+    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
+    dev: false
+
   /de-indent@1.0.2:
     resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
 
@@ -11385,6 +11392,18 @@ packages:
     dependencies:
       ms: 2.1.3
     dev: true
+
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+    dev: false
 
   /debug@4.3.4(supports-color@8.1.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -12879,6 +12898,10 @@ packages:
     resolution: {integrity: sha512-fBHHqSTFLVnR61C+gltJuE5GkVQMV0S2nqUO8TJ+5Z3qAKG8vAx4FKai1s5jq/inV1+sREynIWSuQ6HgoSXpDQ==}
     dev: false
 
+  /fast-copy@3.0.2:
+    resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
+    dev: false
+
   /fast-decode-uri-component@1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
     dev: false
@@ -12930,6 +12953,10 @@ packages:
   /fast-redact@3.5.0:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
     engines: {node: '>=6'}
+    dev: false
+
+  /fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
     dev: false
 
   /fast-uri@2.3.0:
@@ -13931,6 +13958,10 @@ packages:
       tslib: 2.6.2
     dev: true
 
+  /help-me@5.0.0:
+    resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
+    dev: false
+
   /highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
     dev: true
@@ -14150,7 +14181,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -14378,7 +14409,7 @@ packages:
     dependencies:
       '@ioredis/commands': 1.2.0
       cluster-key-slot: 1.1.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -15356,6 +15387,11 @@ packages:
   /jiti@1.21.0:
     resolution: {integrity: sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==}
     hasBin: true
+
+  /joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+    dev: false
 
   /js-beautify@1.15.1:
     resolution: {integrity: sha512-ESjNzSlt/sWE8sciZH8kBF8BPlwXPwhR6pWKAw8bw4Bwj+iZcnKW6ONWUutJ7eObuBZQpiIb8S7OYspWrKt7rA==}
@@ -18558,8 +18594,39 @@ packages:
       split2: 4.2.0
     dev: false
 
+  /pino-abstract-transport@1.2.0:
+    resolution: {integrity: sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==}
+    dependencies:
+      readable-stream: 4.5.2
+      split2: 4.2.0
+    dev: false
+
+  /pino-pretty@11.2.2:
+    resolution: {integrity: sha512-2FnyGir8nAJAqD3srROdrF1J5BIcMT4nwj7hHSc60El6Uxlym00UbCCd8pYIterstVBFlMyF1yFV8XdGIPbj4A==}
+    hasBin: true
+    dependencies:
+      colorette: 2.0.20
+      dateformat: 4.6.3
+      fast-copy: 3.0.2
+      fast-safe-stringify: 2.1.1
+      help-me: 5.0.0
+      joycon: 3.1.1
+      minimist: 1.2.8
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 1.1.0
+      pump: 3.0.0
+      readable-stream: 4.5.2
+      secure-json-parse: 2.7.0
+      sonic-boom: 4.1.0
+      strip-json-comments: 3.1.1
+    dev: false
+
   /pino-std-serializers@6.2.2:
     resolution: {integrity: sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==}
+    dev: false
+
+  /pino-std-serializers@7.0.0:
+    resolution: {integrity: sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==}
     dev: false
 
   /pino@8.20.0:
@@ -18577,6 +18644,23 @@ packages:
       safe-stable-stringify: 2.4.3
       sonic-boom: 3.8.1
       thread-stream: 2.4.1
+    dev: false
+
+  /pino@9.4.0:
+    resolution: {integrity: sha512-nbkQb5+9YPhQRz/BeQmrWpEknAaqjpAqRK8NwJpmrX/JHu7JuZC5G1CeAwJDJfGes4h+YihC6in3Q2nGb+Y09w==}
+    hasBin: true
+    dependencies:
+      atomic-sleep: 1.0.0
+      fast-redact: 3.5.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 1.2.0
+      pino-std-serializers: 7.0.0
+      process-warning: 4.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.4.3
+      sonic-boom: 4.1.0
+      thread-stream: 3.1.0
     dev: false
 
   /pirates@4.0.6:
@@ -19728,6 +19812,10 @@ packages:
 
   /process-warning@3.0.0:
     resolution: {integrity: sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==}
+    dev: false
+
+  /process-warning@4.0.0:
+    resolution: {integrity: sha512-/MyYDxttz7DfGMMHiysAsFE4qF+pQYAA8ziO/3NcRVrQ5fSk+Mns4QZA/oRPFzvcqNoVJXQNWNAsdwBXLUkQKw==}
     dev: false
 
   /process@0.11.10:
@@ -21289,6 +21377,12 @@ packages:
       atomic-sleep: 1.0.0
     dev: false
 
+  /sonic-boom@4.1.0:
+    resolution: {integrity: sha512-NGipjjRicyJJ03rPiZCJYjwlsuP2d1/5QUviozRXC7S3WdVWNK5e3Ojieb9CCyfhq2UC+3+SRd9nG3I2lPRvUw==}
+    dependencies:
+      atomic-sleep: 1.0.0
+    dev: false
+
   /sort-keys@1.1.2:
     resolution: {integrity: sha512-vzn8aSqKgytVik0iwdBEi+zevbTYZogewTUM6dtpmGwEcdzbub/TX4bCzRhebDCRC3QzXgJsLRKB2V/Oof7HXg==}
     engines: {node: '>=0.10.0'}
@@ -21721,7 +21815,6 @@ packages:
   /strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
-    dev: true
 
   /strnum@1.0.5:
     resolution: {integrity: sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==}
@@ -22039,6 +22132,12 @@ packages:
 
   /thread-stream@2.4.1:
     resolution: {integrity: sha512-d/Ex2iWd1whipbT681JmTINKw0ZwOUBZm7+Gjs64DHuX34mmw8vJL2bFAaNacaW72zYiTJxSHi5abUuOi5nsfg==}
+    dependencies:
+      real-require: 0.2.0
+    dev: false
+
+  /thread-stream@3.1.0:
+    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
     dependencies:
       real-require: 0.2.0
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,15 +159,18 @@ importers:
       nunjucks:
         specifier: ^3.2.4
         version: 3.2.4
+      pino:
+        specifier: ^9.4.0
+        version: 9.4.0
+      pino-pretty:
+        specifier: ^11.2.2
+        version: 11.2.2
       tsx:
         specifier: ^4.7.2
         version: 4.7.2
       typescript:
         specifier: ^5.3.3
         version: 5.4.4
-      winston:
-        specifier: ^3.13.1
-        version: 3.13.1
     devDependencies:
       '@types/config':
         specifier: ^3.3.3
@@ -2545,11 +2548,6 @@ packages:
     dev: true
     optional: true
 
-  /@colors/colors@1.6.0:
-    resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
-    engines: {node: '>=0.1.90'}
-    dev: false
-
   /@commitlint/cli@18.6.1(@types/node@20.12.12)(typescript@5.4.4):
     resolution: {integrity: sha512-5IDE0a+lWGdkOvKH892HHAZgbAjcj1mT5QrfA/SVbLJV/BbBMGyKN0W5mhgjekPJJwEQdVNvhl9PwUacY58Usw==}
     engines: {node: '>=v18'}
@@ -3140,14 +3138,6 @@ packages:
       postcss: 8.4.38
     dev: false
 
-  /@dabh/diagnostics@2.0.3:
-    resolution: {integrity: sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==}
-    dependencies:
-      colorspace: 1.1.4
-      enabled: 2.0.0
-      kuler: 2.0.0
-    dev: false
-
   /@discoveryjs/json-ext@0.5.7:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
@@ -3156,7 +3146,7 @@ packages:
     resolution: {integrity: sha512-GMXtFVqd3FgUlTtPL/GDc+3GhwvfZ0kSuegCvVVqb58kd+0I6U6u7PL8QFRLHtwzqLEBmYLdwr4PRkBAWKGlzA==}
     engines: {node: '>=12'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       hpagent: 0.1.2
       ms: 2.1.3
       secure-json-parse: 2.7.0
@@ -7969,10 +7959,6 @@ packages:
       '@types/node': 20.12.12
     dev: true
 
-  /@types/triple-beam@1.3.5:
-    resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
-    dev: false
-
   /@types/trusted-types@2.0.7:
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
     dev: true
@@ -8748,7 +8734,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -9237,7 +9223,7 @@ packages:
     dependencies:
       '@fastify/error': 3.4.1
       archy: 1.0.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       fastq: 1.17.1
     transitivePeerDependencies:
       - supports-color
@@ -10247,13 +10233,6 @@ packages:
     hasBin: true
     dev: false
 
-  /color@3.2.1:
-    resolution: {integrity: sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==}
-    dependencies:
-      color-convert: 1.9.3
-      color-string: 1.9.1
-    dev: false
-
   /color@4.2.3:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
@@ -10267,13 +10246,6 @@ packages:
 
   /colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
-
-  /colorspace@1.1.4:
-    resolution: {integrity: sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==}
-    dependencies:
-      color: 3.2.1
-      text-hex: 1.0.0
-    dev: false
 
   /combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -11916,10 +11888,6 @@ packages:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
     engines: {node: '>= 4'}
 
-  /enabled@2.0.0:
-    resolution: {integrity: sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==}
-    dev: false
-
   /encodeurl@1.0.2:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
     engines: {node: '>= 0.8'}
@@ -13019,10 +12987,6 @@ packages:
       pend: 1.2.0
     dev: true
 
-  /fecha@4.2.3:
-    resolution: {integrity: sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==}
-    dev: false
-
   /fetch-retry@5.0.6:
     resolution: {integrity: sha512-3yurQZ2hD9VISAhJJP9bpYFNQrHHBXE2JxxjY5aLEcDi46RmAzJE2OC9FAde0yis5ElW0jTTzs0zfg/Cca4XqQ==}
     dev: true
@@ -13245,10 +13209,6 @@ packages:
     dependencies:
       inherits: 2.0.4
       readable-stream: 2.3.8
-
-  /fn.name@1.1.0:
-    resolution: {integrity: sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==}
-    dev: false
 
   /follow-redirects@1.15.6:
     resolution: {integrity: sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==}
@@ -14181,7 +14141,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -15638,10 +15598,6 @@ packages:
     resolution: {integrity: sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==}
     engines: {node: '>= 8'}
 
-  /kuler@2.0.0:
-    resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
-    dev: false
-
   /language-subtag-registry@0.3.22:
     resolution: {integrity: sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==}
     dev: true
@@ -15941,18 +15897,6 @@ packages:
       strip-ansi: 7.1.0
       wrap-ansi: 9.0.0
     dev: true
-
-  /logform@2.6.0:
-    resolution: {integrity: sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==}
-    engines: {node: '>= 12.0.0'}
-    dependencies:
-      '@colors/colors': 1.6.0
-      '@types/triple-beam': 1.3.5
-      fecha: 4.2.3
-      ms: 2.1.3
-      safe-stable-stringify: 2.4.3
-      triple-beam: 1.4.1
-    dev: false
 
   /longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -18097,12 +18041,6 @@ packages:
     dependencies:
       wrappy: 1.0.2
 
-  /one-time@1.0.0:
-    resolution: {integrity: sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==}
-    dependencies:
-      fn.name: 1.1.0
-    dev: false
-
   /onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
@@ -18613,7 +18551,7 @@ packages:
       joycon: 3.1.1
       minimist: 1.2.8
       on-exit-leak-free: 2.1.2
-      pino-abstract-transport: 1.1.0
+      pino-abstract-transport: 1.2.0
       pump: 3.0.0
       readable-stream: 4.5.2
       secure-json-parse: 2.7.0
@@ -22100,10 +22038,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /text-hex@1.0.0:
-    resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
-    dev: false
-
   /text-segmentation@1.0.3:
     resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
     requiresBuild: true
@@ -22270,11 +22204,6 @@ packages:
     resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
     engines: {node: '>=8'}
     dev: true
-
-  /triple-beam@1.4.1:
-    resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
-    engines: {node: '>= 14.0.0'}
-    dev: false
 
   /trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
@@ -23931,32 +23860,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       string-width: 4.2.3
-
-  /winston-transport@4.7.0:
-    resolution: {integrity: sha512-ajBj65K5I7denzer2IYW6+2bNIVqLGDHqDw3Ow8Ohh+vdW+rv4MZ6eiDvHoKhfJFZ2auyN8byXieDDJ96ViONg==}
-    engines: {node: '>= 12.0.0'}
-    dependencies:
-      logform: 2.6.0
-      readable-stream: 3.6.2
-      triple-beam: 1.4.1
-    dev: false
-
-  /winston@3.13.1:
-    resolution: {integrity: sha512-SvZit7VFNvXRzbqGHsv5KSmgbEYR5EiQfDAL9gxYkRqa934Hnk++zze0wANKtMHcy/gI4W/3xmSDwlhf865WGw==}
-    engines: {node: '>= 12.0.0'}
-    dependencies:
-      '@colors/colors': 1.6.0
-      '@dabh/diagnostics': 2.0.3
-      async: 3.2.5
-      is-stream: 2.0.1
-      logform: 2.6.0
-      one-time: 1.0.0
-      readable-stream: 3.6.2
-      safe-stable-stringify: 2.4.3
-      stack-trace: 0.0.10
-      triple-beam: 1.4.1
-      winston-transport: 4.7.0
-    dev: false
 
   /with@7.0.2:
     resolution: {integrity: sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==}

--- a/services/mail/config/custom-environment-variables.json
+++ b/services/mail/config/custom-environment-variables.json
@@ -1,5 +1,10 @@
 {
   "allowedOrigins": "API_ALLOWED_ORIGINS",
+  "log": {
+    "level": "LOG_LEVEL",
+    "dir": "LOG_DIR",
+    "ignore": "LOG_IGNORE"
+  },
   "redis": {
     "host": "REDIS_HOST",
     "port": { "__name": "REDIS_PASSWORD", "__format": "number" },

--- a/services/mail/config/default.json
+++ b/services/mail/config/default.json
@@ -1,5 +1,10 @@
 {
   "allowedOrigins": "*",
+  "log": {
+    "level": "debug",
+    "dir": "",
+    "ignore": ["hostname"]
+  },
   "redis": {
     "host": "redis",
     "port": 6379,

--- a/services/mail/package.json
+++ b/services/mail/package.json
@@ -33,7 +33,6 @@
     "nodemailer": "^6.9.14",
     "nunjucks": "^3.2.4",
     "pino": "^9.4.0",
-    "pino-pretty": "^11.2.2",
     "tsx": "^4.7.2",
     "typescript": "^5.3.3"
   },
@@ -42,7 +41,8 @@
     "@types/mjml": "^4.7.4",
     "@types/node": "^20.10.6",
     "@types/nodemailer": "^6.4.15",
-    "@types/nunjucks": "^3.2.6"
+    "@types/nunjucks": "^3.2.6",
+    "pino-pretty": "^11.2.2"
   },
   "engines": {
     "node": "^18"

--- a/services/mail/package.json
+++ b/services/mail/package.json
@@ -32,9 +32,10 @@
     "mjml": "^4.14.1",
     "nodemailer": "^6.9.14",
     "nunjucks": "^3.2.4",
+    "pino": "^9.4.0",
+    "pino-pretty": "^11.2.2",
     "tsx": "^4.7.2",
-    "typescript": "^5.3.3",
-    "winston": "^3.13.1"
+    "typescript": "^5.3.3"
   },
   "devDependencies": {
     "@types/config": "^3.3.3",

--- a/services/mail/src/app.ts
+++ b/services/mail/src/app.ts
@@ -11,12 +11,22 @@ const server = http.createServer((req, res) => {
     res.writeHead(200);
     res.end('OK');
   }).catch((err) => {
-    appLogger.error(`Error when getting services: ${err}`);
+    appLogger.error({
+      scope: 'ping',
+      err,
+      msg: 'Error when getting services',
+    });
     res.writeHead(500);
     res.end(`ERROR: ${err}`);
   });
 });
 
 server.listen(8080, 'localhost', () => {
-  appLogger.info('Server running on http://localhost:8080');
+  appLogger.info({
+    scope: 'http',
+    address: 'http://localhost:8080',
+    startupDuration: process.uptime(),
+    startupDurationUnit: 's',
+    msg: 'Service listening',
+  });
 });

--- a/services/mail/src/lib/bull/jobs/sendReportMail.js
+++ b/services/mail/src/lib/bull/jobs/sendReportMail.js
@@ -4,7 +4,7 @@ const { Queue, Job } = require('bullmq');
 const { format, parseISO } = require('date-fns');
 
 const config = require('../../config').default;
-const { appLogger: logger } = require('../../logger');
+const { appLogger } = require('../../logger');
 const { generateMail, sendMail } = require('../../mail');
 const { b64ToString, isFulfilled, stringToB64 } = require('../../utils');
 
@@ -37,6 +37,7 @@ const {
 
 /**
  * @param {ErrorReportPrams} param0
+ * @param {import('pino').Logger} logger
  */
 const sendErrorReport = async ({
   data,
@@ -45,7 +46,7 @@ const sendErrorReport = async ({
   filename,
   date,
   dateStr,
-}) => {
+}, logger) => {
   // TODO[feat]: Ignore team if test report ?
   const to = [...new Set([data.contact ?? '', team])];
 
@@ -64,7 +65,11 @@ const sendErrorReport = async ({
     subject: `Erreur de Reporting ezMESURE [${dateStr}] - ${data.task.name}`,
     body: await generateMail('error', { ...bodyData, error, date: format(date, 'dd/MM/yyyy à HH:mm:ss') }),
   });
-  logger.info(`[mail] [${process.pid}] Error report [${filename}] sent to [${to.filter((v) => v).join(', ')}]`);
+  logger.info({
+    filename,
+    to: to.filter((v) => v),
+    msg: 'Error report sent to targets',
+  });
 };
 
 /**
@@ -82,6 +87,7 @@ const sendErrorReport = async ({
 
 /**
  * @param {SuccessReportParams} param0
+ * @param {import('pino').Logger} logger
  */
 const sendSuccessReport = async ({
   task,
@@ -89,7 +95,7 @@ const sendSuccessReport = async ({
   dateStr,
   bodyData,
   filename,
-}) => {
+}, logger) => {
   // Send one email per target to allow un-subscription prefill
   const targets = await Promise.allSettled(
     task.targets.map(async (to) => {
@@ -107,22 +113,30 @@ const sendSuccessReport = async ({
         });
 
         return to;
-      } catch (error) {
-        if (error instanceof Error) {
-          logger.error(`[mail] [${process.pid}] Report [${filename}] wan't sent to [${to}] with error: {${error.message}}`);
-        } else {
-          logger.error(`[cron] [${process.pid}] Unexpected error when sending report [${filename}] wan't sent to [${to}]: {${error}}`);
-        }
-        throw error;
+      } catch (err) {
+        logger.error({
+          filename,
+          to,
+          err,
+          msg: 'Error when sending report',
+        });
+        throw err;
       }
     }),
   );
 
   const successTargets = targets.filter(isFulfilled).map(({ value }) => value);
   if (successTargets.length > 0) {
-    logger.info(`[mail] [${process.pid}] Report [${filename}] sent to [${successTargets.join(', ')}]`);
+    logger.info({
+      filename,
+      targets: successTargets,
+      msg: 'Report sent to targets',
+    });
   } else {
-    logger.error(`[mail] [${process.pid}] Report [${filename}] wasn't sent to anyone (see previous logs)`);
+    logger.warn({
+      filename,
+      msg: 'No target to send report',
+    });
   }
 };
 
@@ -130,9 +144,10 @@ const sendSuccessReport = async ({
  * @param {MailResult} data
  * @param {Date} date
  * @param {string} dateStr
+ * @param {import('pino').Logger} logger
  * @returns {Promise<void>}
  */
-const sendReport = (data, date, dateStr) => {
+const sendReport = (data, date, dateStr, logger) => {
   const filename = data.url.replace(/^.*\//, '');
 
   /** @type {Omit<MailOptions, 'to' | 'body' | 'subject'>} */
@@ -157,7 +172,7 @@ const sendReport = (data, date, dateStr) => {
       options,
       bodyData,
       task: data.task,
-    });
+    }, logger);
   }
   return sendErrorReport({
     data,
@@ -166,7 +181,7 @@ const sendReport = (data, date, dateStr) => {
     dateStr,
     filename,
     options,
-  });
+  }, logger);
 };
 
 /**
@@ -181,8 +196,9 @@ const sendReport = (data, date, dateStr) => {
  * @param {ErrorParams} data
  * @param {Date} date
  * @param {string} dateStr
+ * @param {import('pino').Logger} logger
  */
-const sendError = async (data, date, dateStr) => {
+const sendError = async (data, date, dateStr, logger) => {
   await sendMail({
     attachments: [{
       filename: data.filename,
@@ -196,7 +212,10 @@ const sendError = async (data, date, dateStr) => {
       date: format(date, 'dd/MM/yyyy à HH:mm:ss'),
     }),
   });
-  logger.info(`[mail] [${process.pid}] Error sent to [${team}]`);
+  logger.info({
+    team,
+    msg: 'Error report sent to team',
+  });
 };
 
 /**
@@ -204,6 +223,8 @@ const sendError = async (data, date, dateStr) => {
  * @returns {Promise<void>}
  */
 module.exports = async (j) => {
+  const logger = appLogger.child({ scope: 'bull', job: j.id });
+
   // Re-getting job from it's id and queue to get child jobs
   // See https://github.com/taskforcesh/bullmq/issues/753
   /** @type {Queue<MailResult>} */
@@ -221,21 +242,20 @@ module.exports = async (j) => {
 
   try {
     if (data && !job.data.error) {
-      await sendReport(data, date, dateStr);
+      await sendReport(data, date, dateStr, logger);
       return;
     }
 
     if (job.data.error) {
-      await sendError(job.data, date, dateStr);
+      await sendError(job.data, date, dateStr, logger);
       return;
     }
 
     throw new Error('No suitable data found');
-  } catch (error) {
-    if (error instanceof Error) {
-      logger.error(`[mail] [${process.pid}] Error when sending incoming report: {${error.message}}`);
-    } else {
-      logger.error(`[cron] [${process.pid}] Unexpected error when sending incoming report: {${error}}`);
-    }
+  } catch (err) {
+    logger.error({
+      err,
+      msg: 'Error when sending report',
+    });
   }
 };

--- a/services/mail/src/lib/logger.ts
+++ b/services/mail/src/lib/logger.ts
@@ -1,53 +1,52 @@
 import pino from 'pino';
-import pretty from 'pino-pretty';
 
 import { resolve } from 'node:path';
 
 import config from '~/lib/config';
 
-type LoggerOptions = Omit<pino.LoggerOptions, 'level'> & { name: string };
+type LoggerOptions = Omit<pino.LoggerOptions, 'level' | 'transports'> & { name: string };
 
 const { level: l, dir, ignore } = config.log;
 const level = l as pino.Level;
 
-function getStdOut() {
+function getStdOutTarget(): pino.TransportTargetOptions {
   if (process.env.NODE_ENV === 'production') {
-    return process.stdout;
+    return { target: 'pino/file', options: { destination: 1 } };
   }
 
-  // Setup pretty logger on dev
-  return pretty({
-    ignore: [...ignore, 'scope'].join(','),
-    colorize: true,
-    messageFormat: ({ scope, msg }) => {
-      if (scope) {
-        return `[${scope}] ${msg || ''}`;
-      }
-      return `${msg || ''}`;
+  return {
+    target: 'pino-pretty',
+    options: {
+      ignore: [...ignore, 'scope'].join(','),
+      colorize: true,
+      messageFormat: '{if scope}[{scope}]{end} {msg}',
     },
-  });
+  };
 }
 
 function createLogger(options: LoggerOptions) {
-  const streams: pino.StreamEntry[] = [{ level, stream: getStdOut() }];
+  const targets: pino.TransportTargetOptions[] = [
+    { level, ...getStdOutTarget() },
+  ];
 
   // If needed add logs into a file
   if (dir) {
-    streams.push({
-      level,
-      stream: pino.destination({
-        dest: resolve(dir, `${options.name}.log`),
+    targets.push({
+      target: 'pino/file',
+      options: {
+        destination: resolve(dir, `${options.name}.log`),
         sync: false,
         ignore: ignore.join(','),
-      }),
+      },
     });
   }
 
-  return pino(
-    { ...options, level },
-    pino.multistream(streams),
-  );
+  return pino({
+    ...options,
+    level,
+    transport: { targets },
+  });
 }
 
-// eslint-disable-next-line import/prefer-default-export
+export const accessLogger = createLogger({ name: 'access' });
 export const appLogger = createLogger({ name: 'app' });

--- a/services/mail/src/lib/logger.ts
+++ b/services/mail/src/lib/logger.ts
@@ -33,6 +33,7 @@ function createLogger(options: LoggerOptions) {
   if (dir) {
     targets.push({
       target: 'pino/file',
+      level,
       options: {
         destination: resolve(dir, `${options.name}.log`),
         sync: false,

--- a/services/mail/src/lib/mail.ts
+++ b/services/mail/src/lib/mail.ts
@@ -8,7 +8,9 @@ import nunjucks from 'nunjucks';
 import { differenceInMilliseconds } from 'date-fns';
 
 import config from '~/lib/config';
-import { appLogger as logger } from '~/lib/logger';
+import { appLogger } from '~/lib/logger';
+
+const logger = appLogger.child({ scope: 'nodemailer' });
 
 const {
   smtp,
@@ -21,7 +23,10 @@ const images = readdirSync(join(templatesPath, 'images'));
 const transporter = createTransport(smtp);
 
 transporter.on('error', (err) => {
-  logger.error(`[nodemailer] Error on transporter: {${err.message}}`);
+  logger.error({
+    err,
+    msg: 'Error on transporter',
+  });
 });
 
 export type MailOptions = {
@@ -64,20 +69,24 @@ export const generateMail = async (template: string, data: object) => {
 };
 
 (async () => {
-  const start = new Date();
+  const start = Date.now();
   try {
-    logger.verbose('[nodemailer] Checking SMTP connection...');
+    logger.debug('Checking SMTP connection...');
     await SMTPPing();
 
-    const end = new Date();
-    logger.info(`[nodemailer] Connected to SMTP in [${differenceInMilliseconds(end, start)}]ms`);
-  } catch (error) {
-    const end = new Date();
-
-    if (error instanceof Error) {
-      logger.error(`[nodemailer] Error when trying connection to SMTP in [${differenceInMilliseconds(end, start)}]ms: {${error.message}}`);
-    } else {
-      logger.error(`[nodemailer] Unexpected error when trying connection to SMTP in [${differenceInMilliseconds(end, start)}]ms: {${error}}`);
-    }
+    const end = Date.now();
+    logger.debug({
+      duration: differenceInMilliseconds(end, start),
+      durationUnit: 'ms',
+      msg: 'Connected to SMTP',
+    });
+  } catch (err) {
+    const end = Date.now();
+    logger.error({
+      duration: differenceInMilliseconds(end, start),
+      durationUnit: 'ms',
+      err,
+      msg: 'Error when trying connection to SMTP',
+    });
   }
 })();

--- a/services/mail/src/models/healthchecks.ts
+++ b/services/mail/src/models/healthchecks.ts
@@ -4,7 +4,6 @@ import { setTimeout } from 'node:timers/promises';
 
 import { redisPing } from '~/lib/bull';
 import { SMTPPing } from '~/lib/mail';
-import { appLogger as logger } from '~/lib/logger';
 
 const pingers = {
   smtp: SMTPPing,
@@ -38,9 +37,7 @@ export const ping = async (
 
     const ms = differenceInMilliseconds(new Date(), start);
     if (!res) {
-      const msg = `Service [${service}] is not available after [${ms}]/[${timeout}]ms`;
-      logger.warn(`[ping] ${msg}`);
-      throw new Error(msg);
+      throw new Error(`Service [${service}] is not available after [${ms}]/[${timeout}]ms`);
     }
   } catch (error) {
     throw new Error(error instanceof Error ? error.message : `Unexpected error: ${error}`);

--- a/services/report/config/custom-environment-variables.json
+++ b/services/report/config/custom-environment-variables.json
@@ -1,8 +1,12 @@
 {
-  "logLevel": "LOG_LEVEL",
   "port": { "__name": "HTTP_PORT", "__format": "number" },
   "allowedOrigins": "API_ALLOWED_ORIGINS",
   "adminKey": "REPORT_ADMIN_KEY",
+  "log": {
+    "level": "LOG_LEVEL",
+    "dir": "LOG_DIR",
+    "ignore": "LOG_IGNORE"
+  },
   "defaultTemplate": {
     "name": "REPORT_DEFAULT_TEMPLATE_NAME"
   },

--- a/services/report/config/default.json
+++ b/services/report/config/default.json
@@ -1,8 +1,12 @@
 {
-  "logLevel": "debug",
   "port": 8080,
   "allowedOrigins": "*",
   "adminKey": "00000000-0000-0000-0000-000000000000",
+  "log": {
+    "level": "debug",
+    "dir": "",
+    "ignore": ["hostname"]
+  },
   "defaultTemplate": {
     "name": "scratch",
     "id": ""

--- a/services/report/package.json
+++ b/services/report/package.json
@@ -54,7 +54,6 @@
     "jspdf-autotable": "^3.8.1",
     "lodash": "^4.17.21",
     "pino": "^9.4.0",
-    "pino-pretty": "^11.2.2",
     "swagger-ui-dist": "^5.10.5",
     "tsx": "^4.7.2",
     "typescript": "^5.3.3",
@@ -67,7 +66,8 @@
     "@types/lodash": "^4.17.7",
     "@types/node": "^20.10.6",
     "@types/swagger-ui-dist": "^3.30.5",
-    "prisma": "^5.7.1"
+    "prisma": "^5.7.1",
+    "pino-pretty": "^11.2.2"
   },
   "engines": {
     "node": "^18"

--- a/services/report/package.json
+++ b/services/report/package.json
@@ -53,12 +53,13 @@
     "jspdf": "^2.5.1",
     "jspdf-autotable": "^3.8.1",
     "lodash": "^4.17.21",
+    "pino": "^9.4.0",
+    "pino-pretty": "^11.2.2",
     "swagger-ui-dist": "^5.10.5",
     "tsx": "^4.7.2",
     "typescript": "^5.3.3",
     "vega": "^5.27.0",
-    "vega-lite": "^5.16.3",
-    "winston": "^3.13.1"
+    "vega-lite": "^5.16.3"
   },
   "devDependencies": {
     "@types/chroma-js": "^2.4.4",

--- a/services/report/src/lib/bull/jobs/generateReport.js
+++ b/services/report/src/lib/bull/jobs/generateReport.js
@@ -6,7 +6,7 @@ const { join } = require('node:path');
 
 const config = require('../../config').default;
 const { formatISO } = require('../../date-fns');
-const { appLogger: logger } = require('../../logger');
+const { appLogger } = require('../../logger');
 
 const { generateReport } = require('../../../models/reports');
 
@@ -24,7 +24,14 @@ const { outDir } = config.report;
  * @returns {Promise<{ res: ReportResultType; mailData: Partial<MailResult>; }>}
  */
 module.exports = async (job) => {
-  logger.verbose(`[bull] [${process.pid}] Received generation of "${job.data.task.name}"`);
+  const logger = appLogger.child({
+    scope: 'bull',
+    job: job.id,
+    pid: process.pid,
+    taskName: job.data.task.name,
+  });
+
+  logger.debug('Received generation');
   const {
     id: jobId,
     data: {

--- a/services/report/src/lib/logger.ts
+++ b/services/report/src/lib/logger.ts
@@ -1,52 +1,51 @@
 import pino from 'pino';
-import pretty from 'pino-pretty';
 
 import { resolve } from 'node:path';
 
 import config from '~/lib/config';
 
-type LoggerOptions = Omit<pino.LoggerOptions, 'level'> & { name: string };
+type LoggerOptions = Omit<pino.LoggerOptions, 'level' | 'transports'> & { name: string };
 
 const { level: l, dir, ignore } = config.log;
 const level = l as pino.Level;
 
-function getStdOut() {
+function getStdOutTarget(): pino.TransportTargetOptions {
   if (process.env.NODE_ENV === 'production') {
-    return process.stdout;
+    return { target: 'pino/file', options: { destination: 1 } };
   }
 
-  // Setup pretty logger on dev
-  return pretty({
-    ignore: [...ignore, 'scope'].join(','),
-    colorize: true,
-    messageFormat: ({ scope, msg }) => {
-      if (scope) {
-        return `[${scope}] ${msg || ''}`;
-      }
-      return `${msg || ''}`;
+  return {
+    target: 'pino-pretty',
+    options: {
+      ignore: [...ignore, 'scope'].join(','),
+      colorize: true,
+      messageFormat: '{if scope}[{scope}]{end} {msg}',
     },
-  });
+  };
 }
 
 function createLogger(options: LoggerOptions) {
-  const streams: pino.StreamEntry[] = [{ level, stream: getStdOut() }];
+  const targets: pino.TransportTargetOptions[] = [
+    { level, ...getStdOutTarget() },
+  ];
 
   // If needed add logs into a file
   if (dir) {
-    streams.push({
-      level,
-      stream: pino.destination({
-        dest: resolve(dir, `${options.name}.log`),
+    targets.push({
+      target: 'pino/file',
+      options: {
+        destination: resolve(dir, `${options.name}.log`),
         sync: false,
         ignore: ignore.join(','),
-      }),
+      },
     });
   }
 
-  return pino(
-    { ...options, level },
-    pino.multistream(streams),
-  );
+  return pino({
+    ...options,
+    level,
+    transport: { targets },
+  });
 }
 
 export const accessLogger = createLogger({ name: 'access' });

--- a/services/report/src/lib/logger.ts
+++ b/services/report/src/lib/logger.ts
@@ -4,6 +4,7 @@ import { resolve } from 'node:path';
 
 import config from '~/lib/config';
 
+export type Level = pino.Level;
 type LoggerOptions = Omit<pino.LoggerOptions, 'level' | 'transports'> & { name: string };
 
 const { level: l, dir, ignore } = config.log;

--- a/services/report/src/lib/logger.ts
+++ b/services/report/src/lib/logger.ts
@@ -33,6 +33,7 @@ function createLogger(options: LoggerOptions) {
   if (dir) {
     targets.push({
       target: 'pino/file',
+      level,
       options: {
         destination: resolve(dir, `${options.name}.log`),
         sync: false,

--- a/services/report/src/lib/logger.ts
+++ b/services/report/src/lib/logger.ts
@@ -1,57 +1,53 @@
-import winston from 'winston';
+import pino from 'pino';
+import pretty from 'pino-pretty';
+
+import { resolve } from 'node:path';
+
 import config from '~/lib/config';
 
-const level = config.logLevel;
+type LoggerOptions = Omit<pino.LoggerOptions, 'level'> & { name: string };
 
-const formatter = (info: winston.Logform.TransformableInfo) => `${info.timestamp}${info.label ? ` [${info.label}]` : ''} ${info.level}: ${info.message} ${(info instanceof Error ? `\n\n${info.stack}\n` : '')}`;
+const { level: l, dir, ignore } = config.log;
+const level = l as pino.Level;
 
-const baseLogger: winston.LoggerOptions = {
-  level,
-  exitOnError: false,
-  format: winston.format.combine(
-    winston.format.timestamp(),
-    winston.format.printf(formatter),
-  ),
-};
+function getStdOut() {
+  if (process.env.NODE_ENV === 'production') {
+    return process.stdout;
+  }
 
-winston.loggers.add('app', {
-  ...baseLogger,
-  transports: [
-    new winston.transports.Console({
-      format: winston.format.combine(
-        winston.format.colorize(),
-        winston.format.timestamp(),
-        winston.format.label({ label: 'app' }),
-        winston.format.printf(formatter),
-      ),
-    }),
-    new winston.transports.File({
-      dirname: '/var/log/ezreeport/report',
-      filename: 'app.log',
-    }),
-  ],
-});
+  // Setup pretty logger on dev
+  return pretty({
+    ignore: [...ignore, 'scope'].join(','),
+    colorize: true,
+    messageFormat: ({ scope, msg }) => {
+      if (scope) {
+        return `[${scope}] ${msg || ''}`;
+      }
+      return `${msg || ''}`;
+    },
+  });
+}
 
-winston.loggers.add('access', {
-  ...baseLogger,
-  transports: [
-    new winston.transports.Console({
-      format: winston.format.combine(
-        winston.format.colorize(),
-        winston.format.timestamp(),
-        winston.format.label({ label: 'access' }),
-        winston.format.printf(formatter),
-      ),
-    }),
-    new winston.transports.File({
-      dirname: '/var/log/ezreeport/report',
-      filename: 'access.log',
-    }),
-  ],
-});
+function createLogger(options: LoggerOptions) {
+  const streams: pino.StreamEntry[] = [{ level, stream: getStdOut() }];
 
-export const appLogger = winston.loggers.get('app');
-appLogger.on('error', (err) => appLogger.error(`[winston] ${err.toString()}`));
+  // If needed add logs into a file
+  if (dir) {
+    streams.push({
+      level,
+      stream: pino.destination({
+        dest: resolve(dir, `${options.name}.log`),
+        sync: false,
+        ignore: ignore.join(','),
+      }),
+    });
+  }
 
-export const accessLogger = winston.loggers.get('access');
-accessLogger.on('error', (err) => appLogger.error(`[winston] ${err.toString()}`));
+  return pino(
+    { ...options, level },
+    pino.multistream(streams),
+  );
+}
+
+export const accessLogger = createLogger({ name: 'access' });
+export const appLogger = createLogger({ name: 'app' });

--- a/services/report/src/lib/pdf/index.ts
+++ b/services/report/src/lib/pdf/index.ts
@@ -4,13 +4,15 @@ import { readFile, stat, unlink } from 'node:fs/promises';
 import { jsPDF as PDF } from 'jspdf';
 
 import config from '~/lib/config';
-import { appLogger as logger } from '~/lib/logger';
+import { appLogger } from '~/lib/logger';
 import { format, type Interval } from '~/lib/date-fns';
 
 import { loadImageAsset, registerJSPDFFont } from './utils';
 
 const { logos } = config.pdf;
 const { fontFamily, fonts } = config.report;
+
+const logger = appLogger.child({ scope: 'jspdf' });
 
 // Register fonts
 type JSPDFRegisterableFont = {
@@ -22,7 +24,11 @@ type JSPDFRegisterableFont = {
 
 fonts.forEach(({ path, ...font }: JSPDFRegisterableFont) => {
   registerJSPDFFont(path, font).then(() => {
-    logger.verbose(`[jspdf] Register font: [${path}] as [${font.family} ${font.weight || ''}${font.style || ''}]`);
+    logger.debug({
+      path,
+      font,
+      msg: 'Registered font',
+    });
   });
 });
 

--- a/services/report/src/lib/pdf/markdown.ts
+++ b/services/report/src/lib/pdf/markdown.ts
@@ -12,13 +12,15 @@ type MdParams = {
 
 export type InputMdParams = Omit<MdParams, 'width' | 'height' | 'start'>;
 
-const logger: Console = {
+const logger = appLogger.child({ scope: 'md-to-pdf' });
+
+const mdLogger: Console = {
   ...console,
-  debug: (m, ...args) => appLogger.debug(`[md-to-pdf] ${m} ${args}`),
-  log: (m, ...args) => appLogger.verbose(`[md-to-pdf] ${m} ${args}`),
-  info: (m, ...args) => appLogger.info(`[md-to-pdf] ${m} ${args}`),
-  warn: (m, ...args) => appLogger.warn(`[md-to-pdf] ${m} ${args}`),
-  error: (m, ...args) => appLogger.error(`[md-to-pdf] ${m} ${args}`),
+  debug: (msg, ...args) => logger.trace({ msg, args }),
+  log: (msg, ...args) => logger.debug({ msg, args }),
+  info: (msg, ...args) => logger.info({ msg, args }),
+  warn: (msg, ...args) => logger.warn({ msg, args }),
+  error: (msg, ...args) => logger.error({ msg, args }),
 };
 
 /**
@@ -52,7 +54,7 @@ export const addMdToPDF = async (
   data: string,
   params: MdParams,
 ) => {
-  const mdDoc = await (new MdParser(data, logger)).parse();
+  const mdDoc = await (new MdParser(data, mdLogger)).parse();
 
   await mdDoc.loadImages(
     fetcher,

--- a/services/report/src/lib/pdf/table.ts
+++ b/services/report/src/lib/pdf/table.ts
@@ -2,7 +2,7 @@ import { compile as handlebars } from 'handlebars';
 import autoTable, { type CellDef, type UserOptions } from 'jspdf-autotable';
 import { get, merge } from 'lodash';
 
-import { appLogger as logger } from '~/lib/logger';
+import { appLogger } from '~/lib/logger';
 
 import type { PDFReport } from '.';
 
@@ -13,6 +13,8 @@ export type TableParams = {
   maxHeight?: number,
   totals?: string[],
 } & Omit<UserOptions, 'body' | 'didParseCell' | 'willDrawCell' | 'didDrawCell' | 'didDrawPage'>;
+
+const logger = appLogger.child({ scope: 'jspdf' });
 
 /**
  * Add table to PDF
@@ -110,7 +112,11 @@ export const addTableToPDF = async (
     const maxRows = Math.ceil(maxTableHeight / 29);
     const rowCount = tableData.length + (params.totals ? 1 : 0);
     if (rowCount > maxRows) {
-      logger.warn(`[pdf] Reducing table length from ${tableData.length} to ${maxRows} because table won't fit in slot.`);
+      logger.warn({
+        msg: 'Reducing table length because table won\'t fit in slot',
+        tableDataLength: tableData.length,
+        maxRows,
+      });
       tableData = tableData.slice(0, maxRows - (params.totals ? 1 : 0));
     }
   }

--- a/services/report/src/lib/prisma.ts
+++ b/services/report/src/lib/prisma.ts
@@ -1,6 +1,8 @@
 /* eslint-disable import/no-relative-packages */
 import { PrismaClient } from '../../.prisma/client';
-import { appLogger as logger } from '~/lib/logger';
+import { appLogger } from '~/lib/logger';
+
+const logger = appLogger.child({ scope: 'prisma' });
 
 const client = new PrismaClient({
   log: [
@@ -9,13 +11,13 @@ const client = new PrismaClient({
     { level: 'warn', emit: 'event' },
     { level: 'error', emit: 'event' },
   ],
-  errorFormat: 'pretty',
+  errorFormat: process.env.NODE_ENV === 'production' ? 'minimal' : 'pretty',
 });
 
-client.$on('query', (e) => logger.silly(`[prisma] ${e.query} - ${e.params} (${e.duration}ms)`));
-client.$on('info', (e) => logger.info(`[prisma] ${e.message}`));
-client.$on('warn', (e) => logger.warn(`[prisma] ${e.message}`));
-client.$on('error', (e) => logger.error(`[prisma] ${e.message}`));
+client.$on('query', (e) => logger.trace({ ...e, durationUnit: 'ms' }));
+client.$on('info', (e) => logger.info({ ...e, message: undefined, msg: e.message }));
+client.$on('warn', (e) => logger.warn({ ...e, message: undefined, msg: e.message }));
+client.$on('error', (e) => logger.error({ ...e, message: undefined, msg: e.message }));
 
 export default client;
 

--- a/services/report/src/lib/vega/index.ts
+++ b/services/report/src/lib/vega/index.ts
@@ -7,7 +7,7 @@ import { compile, type TopLevelSpec } from 'vega-lite';
 import type { Mark } from 'vega-lite/build/src/mark';
 
 import config from '~/lib/config';
-import { appLogger as logger } from '~/lib/logger';
+import { appLogger } from '~/lib/logger';
 import type { PDFReport } from '~/lib/pdf';
 
 import localeFR from './locales/fr-FR.json';
@@ -30,6 +30,8 @@ const {
   fonts,
 } = config.report;
 
+const logger = appLogger.child({ scope: 'vega' });
+
 type CanvasRegisterableFont = {
   path: string;
   family: string;
@@ -40,7 +42,11 @@ type CanvasRegisterableFont = {
 // Register fonts in Vega
 fonts.forEach(({ path, ...font }: CanvasRegisterableFont) => {
   registerFont(path, font);
-  logger.verbose(`[vega] Register font: [${path}] as [${font.family} ${font.weight || ''} ${font.style || ''}]`);
+  logger.debug({
+    path,
+    font,
+    msg: 'Registered font',
+  });
 });
 
 /**

--- a/services/report/src/lib/vega/logger.ts
+++ b/services/report/src/lib/vega/logger.ts
@@ -5,9 +5,9 @@ import {
   Warn,
   type LoggerInterface,
 } from 'vega';
-import { appLogger as logger } from '~/lib/logger';
+import { appLogger } from '~/lib/logger';
 
-const messagesToString = (messages: readonly string[]): string => messages.join('. ');
+const logger = appLogger.child({ name: 'vega' });
 
 const logLevelToNumber = (l: string): number => {
   switch (l) {
@@ -23,50 +23,31 @@ const logLevelToNumber = (l: string): number => {
   }
 };
 
-const logLevelToString = (l: number): string => {
-  switch (l) {
-    case Error:
-      return 'error';
-    case Warn:
-      return 'warn';
-    case Info:
-      return 'info';
-    case Debug:
-    default:
-      return 'debug';
-  }
-};
-
 export default class VegaLogger implements LoggerInterface {
   error(...messages: readonly string[]): this {
-    logger.error(`[vega] ${messagesToString(messages)}`);
+    logger.error({ messages });
     return this;
   }
 
   warn(...messages: readonly string[]): this {
-    logger.warn(`[vega] ${messagesToString(messages)}`);
+    logger.warn({ messages });
     return this;
   }
 
   info(...messages: readonly string[]): this {
-    logger.info(`[vega] ${messagesToString(messages)}`);
+    logger.info({ messages });
     return this;
   }
 
   debug(...messages: readonly string[]): this {
-    logger.debug(`[vega] ${messagesToString(messages)}`);
+    logger.debug({ messages });
     return this;
   }
 
   level(l: number): this;
   level(): number;
   level(l?: unknown): number | this {
-    if (typeof l === 'number' && [Error, Warn, Info, Debug].includes(l)) {
-      const newLevel = logLevelToString(l);
-      // eslint-disable-next-line no-restricted-syntax
-      for (const transport of logger.transports) {
-        transport.level = newLevel;
-      }
+    if (typeof l === 'number') {
       return this;
     }
     return logLevelToNumber(logger.level);

--- a/services/report/src/models/access.ts
+++ b/services/report/src/models/access.ts
@@ -1,6 +1,8 @@
 import { Access } from '~/lib/prisma';
 import { appLogger } from '~/lib/logger';
 
+const logger = appLogger.child({ scope: 'perms' });
+
 const accessValues: Record<Access, number> = {
   [Access.READ]: 1,
   [Access.READ_WRITE]: 2,
@@ -24,7 +26,11 @@ const adminPerRoute = new Map<string, boolean>();
  * @param access Access level
  */
 export const registerRouteWithAccess = (route: string, access: Access) => {
-  appLogger.verbose(`[perms] Route [${route}] registered with minimum access: [${access}]`);
+  logger.debug({
+    route,
+    access,
+    msg: 'Registered route with minimum access',
+  });
   accessPerRoute.set(route, accessValues[access]);
 };
 
@@ -35,7 +41,11 @@ export const registerRouteWithAccess = (route: string, access: Access) => {
  * @param isAdminRequired Is admin required
  */
 export const registerRoute = (route: string, isAdminRequired: boolean) => {
-  appLogger.verbose(`[perms] Route [${route}] registered with admin required: [${isAdminRequired}]`);
+  logger.debug({
+    route,
+    isAdminRequired,
+    msg: 'Registered route with admin required',
+  });
   adminPerRoute.set(route, isAdminRequired);
 };
 

--- a/services/report/src/models/healthchecks.ts
+++ b/services/report/src/models/healthchecks.ts
@@ -1,7 +1,7 @@
 import { setTimeout } from 'node:timers/promises';
 
 import { differenceInMilliseconds } from '~/lib/date-fns';
-import { appLogger as logger } from '~/lib/logger';
+import { appLogger } from '~/lib/logger';
 
 import { elasticPing } from '~/lib/elastic';
 import { redisPing } from '~/lib/bull';
@@ -9,6 +9,8 @@ import { dbPing } from '~/lib/prisma';
 
 import { name as serviceName } from '../../package.json';
 import { NotFoundError } from '~/types/errors';
+
+const logger = appLogger.child({ scope: 'ping' });
 
 const pingers: Record<string, () => Promise<number | false>> = {
   [serviceName]: () => Promise.resolve(200),
@@ -73,7 +75,12 @@ export const ping = async (
 
     const ms = differenceInMilliseconds(new Date(), start);
     if (!res) {
-      logger.warn(`[ping] Service [${service}] is not available after [${ms}]/[${timeout}]ms`);
+      logger.warn({
+        service,
+        timeout,
+        respondedAfter: ms,
+        respondedAfterUnit: 'ms',
+      });
     }
     return {
       name: service,

--- a/services/report/src/models/memberships.ts
+++ b/services/report/src/models/memberships.ts
@@ -12,6 +12,8 @@ import { Type, type Static } from '~/lib/typebox';
 
 type InputMembership = Pick<Prisma.MembershipCreateInput, 'access'>;
 
+const logger = appLogger.child({ scope: 'models', model: 'memberships' });
+
 export const MembershipBody = Type.Object({
   access: Type.Enum(Access),
 });
@@ -59,7 +61,11 @@ export const addUserToNamespace = async (
     },
   });
 
-  appLogger.verbose(`[models] Membership between user "${username}" and namespace "${namespaceId}" created`);
+  logger.debug({
+    username,
+    namespaceId,
+    msg: 'Membership created',
+  });
   return membership;
 };
 
@@ -91,7 +97,11 @@ export const updateUserOfNamespace = async (
     },
   });
 
-  appLogger.verbose(`[models] Membership between user "${username}" and namespace "${namespaceId}" updated`);
+  logger.debug({
+    username,
+    namespaceId,
+    msg: 'Membership updated',
+  });
   return membership;
 };
 
@@ -116,7 +126,11 @@ export const removeUserFromNamespace = async (
     },
   });
 
-  appLogger.verbose(`[models] Membership between user "${username}" and namespace "${namespaceId}" deleted`);
+  logger.debug({
+    username,
+    namespaceId,
+    msg: 'Membership deleted',
+  });
   return membership;
 };
 
@@ -145,7 +159,11 @@ export const upsertBulkMembership = async (
   if (!existingMembership) {
     const data = await tx.membership.create({ data: { ...membership, username, namespaceId } });
 
-    appLogger.verbose(`[models] Membership between user "${username}" and namespace "${namespaceId}" will be created via bulk operation`);
+    logger.debug({
+      username,
+      namespaceId,
+      msg: 'Membership will be created via bulk operation',
+    });
     // If namespace doesn't already exist, create it
     return {
       type: 'created',
@@ -159,7 +177,11 @@ export const upsertBulkMembership = async (
       data: { ...membership, username, namespaceId },
     });
 
-    appLogger.verbose(`[models] Membership between user "${username}" and namespace "${namespaceId}" will be updated via bulk operation`);
+    logger.debug({
+      username,
+      namespaceId,
+      msg: 'Membership will be updated via bulk operation',
+    });
     // If namespace already exist, update it
     return {
       type: 'updated',
@@ -188,7 +210,11 @@ export const deleteBulkMembership = async (
     where: { username_namespaceId: { username, namespaceId } },
   });
 
-  appLogger.verbose(`[models] Membership between user "${username}" and namespace "${namespaceId}" will be deleted via bulk operation`);
+  logger.debug({
+    username,
+    namespaceId,
+    msg: 'Membership will be deleted via bulk operation',
+  });
   return {
     type: 'deleted',
     data,

--- a/services/report/src/models/namespaces.ts
+++ b/services/report/src/models/namespaces.ts
@@ -25,6 +25,8 @@ type FullNamespace = Namespace & {
   tasks: Omit<TaskList[number], 'tags' | '_count' | 'namespaceId'>[],
 };
 
+const logger = appLogger.child({ scope: 'models', model: 'namespaces' });
+
 const {
   PaginationQuery: NamespacePaginationQuery,
   buildPrismaArgs,
@@ -170,7 +172,10 @@ export const createNamespace = async (id: string, data: InputNamespace): Promise
     include: prismaNamespaceInclude,
   });
 
-  appLogger.verbose(`[models] Namespace "${id}" created`);
+  logger.debug({
+    id,
+    msg: 'Namespace created',
+  });
   return namespace;
 };
 
@@ -195,7 +200,10 @@ export const deleteNamespaceById = async (id: Namespace['id']): Promise<FullName
     include: prismaNamespaceInclude,
   });
 
-  appLogger.verbose(`[models] Namespace "${id}" deleted`);
+  logger.debug({
+    id,
+    msg: 'Namespace deleted',
+  });
   return namespace;
 };
 
@@ -216,7 +224,10 @@ export const editNamespaceById = (id: Namespace['id'], data: InputNamespace): Pr
     include: prismaNamespaceInclude,
   });
 
-  appLogger.verbose(`[models] Namespace "${id}" updated`);
+  logger.debug({
+    id,
+    msg: 'Namespace updated',
+  });
   return namespace;
 };
 
@@ -272,7 +283,10 @@ const upsertBulkNamespace = async (
   if (!existingNamespace) {
     const data = await tx.namespace.create({ data: { ...inputNamespace, id } });
 
-    appLogger.verbose(`[models] Namespace "${id}" will be created via bulk operation`);
+    logger.debug({
+      id,
+      msg: 'Namespace will be created via bulk operation',
+    });
     // If namespace doesn't already exist, create it
     return {
       type: 'created',
@@ -286,7 +300,10 @@ const upsertBulkNamespace = async (
       data: inputNamespace,
     });
 
-    appLogger.verbose(`[models] Namespace "${id}" will be updated via bulk operation`);
+    logger.debug({
+      id,
+      msg: 'Namespace will be updated via bulk operation',
+    });
     // If namespace already exist and changed, update it
     return {
       type: 'updated',
@@ -311,7 +328,10 @@ const deleteBulkNamespace = async (
 ): Promise<BulkResult<Namespace>> => {
   const data = await tx.namespace.delete({ where: { id } });
 
-  appLogger.verbose(`[models] Namespace "${id}" will be deleted`);
+  logger.debug({
+    id,
+    msg: 'Namespace will be deleted via bulk operation',
+  });
   return {
     type: 'deleted',
     data,

--- a/services/report/src/models/tasks.ts
+++ b/services/report/src/models/tasks.ts
@@ -23,6 +23,8 @@ import type { FullTasksPreset } from '~/models/tasksPresets';
 
 // #region Input types
 
+const logger = appLogger.child({ scope: 'models', model: 'tasks' });
+
 const {
   PaginationQuery: TaskPaginationQuery,
   buildPrismaArgs,
@@ -466,7 +468,10 @@ export const createTask = async (
     select: prismaTaskSelect,
   });
 
-  appLogger.verbose(`[models] Task "${id}" created`);
+  logger.debug({
+    id,
+    msg: 'Task created',
+  });
   return castFullTask(task);
 };
 
@@ -520,7 +525,10 @@ export const deleteTaskById = async (id: PrismaTask['id'], namespaceIds?: Namesp
     select: prismaTaskSelect,
   });
 
-  appLogger.verbose(`[models] Task "${id}" deleted`);
+  logger.debug({
+    id,
+    msg: 'Task deleted',
+  });
   return castFullTask(task);
 };
 
@@ -597,7 +605,10 @@ export const patchTaskByIdWithHistory = async (
     select: prismaTaskSelect,
   });
 
-  appLogger.verbose(`[models] Task "${id}" edited`);
+  logger.debug({
+    id,
+    msg: 'Task edited',
+  });
   return castFullTask(task);
 };
 

--- a/services/report/src/models/tasksPresets.ts
+++ b/services/report/src/models/tasksPresets.ts
@@ -2,9 +2,14 @@ import { appLogger } from '~/lib/logger';
 import { type Static, Type, Value } from '~/lib/typebox';
 
 import prisma, {
-  Recurrence, Template as PrismaTemplate, TaskPreset as PrismaTaskPreset, Prisma,
+  Recurrence,
+  Template as PrismaTemplate,
+  TaskPreset as PrismaTaskPreset,
+  Prisma,
 } from '~/lib/prisma';
 import { TagTemplate, type FullTemplate } from '~/models/templates';
+
+const logger = appLogger.child({ scope: 'models', model: 'tasks-presets' });
 
 export const TasksPreset = Type.Object({
   name: Type.String({ minLength: 1 }),
@@ -139,8 +144,11 @@ export const createTasksPreset = async (
       template: templateInclude,
     },
   });
-  appLogger.verbose(`[models] Tasks' preset "${preset.id}" created`);
 
+  logger.debug({
+    id: preset.id,
+    msg: 'Tasks\' preset created',
+  });
   return castTasksPreset(preset);
 };
 
@@ -166,8 +174,10 @@ export const deleteTasksPresetById = async (id: string): Promise<FullTasksPreset
     },
   });
 
-  appLogger.verbose(`[models] Tasks' preset "${preset.id}" deleted`);
-
+  logger.debug({
+    id: preset.id,
+    msg: 'Tasks\' preset deleted',
+  });
   return castTasksPreset(preset);
 };
 
@@ -201,5 +211,9 @@ export const editTasksPresetById = async (
     },
   });
 
+  logger.debug({
+    id: preset.id,
+    msg: 'Tasks\' preset updated',
+  });
   return castTasksPreset(preset);
 };

--- a/services/report/src/models/templates.ts
+++ b/services/report/src/models/templates.ts
@@ -12,6 +12,8 @@ import {
 
 import { Layout } from './layouts';
 
+const logger = appLogger.child({ scope: 'models', model: 'templates' });
+
 export const Template = Type.Object({
   layouts: Type.Array(
     Layout,
@@ -250,7 +252,11 @@ export const createTemplate = async (
       presets: true,
     },
   });
-  appLogger.verbose(`[models] Template "${template.id}" created`);
+
+  logger.debug({
+    id: template.id,
+    msg: 'Template created',
+  });
 
   const { tasks, presets, ...t } = template;
   return {
@@ -290,7 +296,12 @@ export const linkTaskToTemplate = async (id: Task['id'], templateId: FullTemplat
       id,
     },
   });
-  appLogger.verbose(`[models] Task "${id}" linked to Template "${template.id}"`);
+
+  logger.debug({
+    id: template.id,
+    taskId: id,
+    msg: 'Task linked to template',
+  });
 
   return res;
 };
@@ -337,7 +348,13 @@ export const unlinkTaskFromTemplate = async (id: Task['id'], origin: string, tx:
       id,
     },
   });
-  appLogger.verbose(`[models] Task "${id}" unlinked from Template "${task.extends.id}" (now linked to "${config.defaultTemplate.id}")`);
+
+  logger.debug({
+    id: task.extends.id,
+    taskId: id,
+    defaultTemplateId: config.defaultTemplate.id,
+    msg: 'Task unlinked from template',
+  });
 
   return res;
 };
@@ -374,7 +391,10 @@ export const deleteTemplateById = async (id: string): Promise<FullTemplate | nul
     });
   });
 
-  appLogger.verbose(`[models] Template "${id}" deleted`);
+  logger.debug({
+    id: template.id,
+    msg: 'Template deleted',
+  });
 
   const { tasks, presets, ...t } = template;
   return {
@@ -415,7 +435,11 @@ export const editTemplateById = async (
       presets: true,
     },
   });
-  appLogger.verbose(`[models] Template "${id}" updated`);
+
+  logger.debug({
+    id: template.id,
+    msg: 'Template updated',
+  });
 
   const { tasks, presets, ...t } = template;
   return {

--- a/services/report/src/plugins/logger.ts
+++ b/services/report/src/plugins/logger.ts
@@ -24,7 +24,12 @@ const logRequest = (request: FastifyRequest, reply?: FastifyReply) => {
     log = accessLogger.info;
   }
 
-  log(`${request.method} ${request.url} - ${reply?.statusCode ?? 0} (${duration})`);
+  log({
+    method: request.method,
+    url: request.url,
+    statusCode: reply?.statusCode ?? 0,
+    duration,
+  });
 };
 
 /**

--- a/services/report/src/routes/v1/health.ts
+++ b/services/report/src/routes/v1/health.ts
@@ -10,6 +10,7 @@ const router: FastifyPluginAsync = async (fastify) => {
    */
   fastify.get(
     '/',
+    { logLevel: 'debug' },
     async () => ({
       content: {
         current: checks.serviceName,
@@ -24,6 +25,7 @@ const router: FastifyPluginAsync = async (fastify) => {
    */
   fastify.get(
     '/_all',
+    { logLevel: 'debug' },
     async () => ({
       content: await Promise.all(
         Array.from(checks.services).map((s) => checks.ping(s)),
@@ -40,6 +42,7 @@ const router: FastifyPluginAsync = async (fastify) => {
   fastify.get<{ Params: Static<typeof GetServiceParams> }>(
     '/:service',
     {
+      logLevel: 'debug',
       schema: {
         params: GetServiceParams,
       },


### PR DESCRIPTION
# API & Mail

- Switched from `winston` to `pino`
- Logs are available through `stdout`
 - They're prettyfied through `pino-pretty` only if `NODE_ENV` is not `production`
 - Can be mirrored in one file if `LOG_DIR` or `log.dir` is set (see [Pino docs](https://getpino.io/#/docs/help?id=rotate) on how to rotate files)
 